### PR TITLE
Pass any options in the ajax 'data' parameter on to jQuery.ajax. This…

### DIFF
--- a/dist/eModal.js
+++ b/dist/eModal.js
@@ -301,12 +301,13 @@
                 deferred: dfd,
                 loading: true,
                 title: data.title || title || defaultSettings.title,
-                url: data.url || data
+                url: data.url || data,
+                dataType: 'text'
             };
 
             if (data.url) { $.extend(params, data); }
 
-            $.ajax({ url: params.url, dataType: 'text' })
+            $.ajax(params)
                 .success(ok)
                 .fail(error);
 


### PR DESCRIPTION
… makes the library much more flexible, as it allows the user to set headers, add authentication information, etc.